### PR TITLE
Add setting to disable Seti icons

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,0 +1,18 @@
+{CompositeDisposable, Disposable} = require 'atom'
+subscriptions = null
+
+hideIcons = (hide) ->
+  hideClass = "seti-ui-no-icons"
+  atom.views.getView(atom.workspace)?.classList.toggle hideClass, hide
+
+
+module.exports =
+  activate: ->
+    subscriptions = new CompositeDisposable()
+    subscriptions.add atom.config.observe 'seti-classic.fileIcons', (enabled) =>
+      hideIcons not enabled
+    subscriptions.add new Disposable => hideIcons(false)
+    undefined
+
+  deactivate: =>
+    subscriptions?.dispose()

--- a/package.json
+++ b/package.json
@@ -10,5 +10,14 @@
   },
   "engines": {
     "atom": ">0.99.0"
+  },
+  "configSchema": {
+    "fileIcons": {
+      "title": "Custom Icons",
+      "order": 1,
+      "description": "Disable this if you are using file-icons or another atom file icon package (or simply don't want custom icons)",
+      "type": "boolean",
+      "default": true
+    }
   }
 }


### PR DESCRIPTION
Implements a theme option to disable Seti's icons, which Seti UI introduced in their last major version.

Fixes DanBrooker/file-icons#475.

/cc @mikeerickson